### PR TITLE
Add project skills to repo for cross-machine reuse

### DIFF
--- a/.claude/skills/add-blog-link/SKILL.md
+++ b/.claude/skills/add-blog-link/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-blog-link
+description: >
+  Add a Medium or LinkedIn article link to the blog section of hamxiaoz.github.com.
+  Use when the user provides a Medium or LinkedIn article URL and wants to create a
+  new entry in content/blog/ that shows up on the /blog page as an external link.
+  Trigger: "add blog link", "add to blog", "/add-blog-link",
+  plus any time user pastes a Medium/LinkedIn URL with intent to save it to the blog section.
+allowed-tools:
+  - WebFetch
+  - Write
+  - AskUserQuestion
+---
+
+# add-blog-link
+
+Add a Medium or LinkedIn article to the blog section of hamxiaoz.github.com.
+The article will appear in the /blog page and link out to the original URL.
+
+## Steps
+
+1. **Parse input** — extract the URL from the user's message. Also note if they specified a category.
+
+2. **Ask for category if missing** — if no category was given, ask:
+   > Which category? `诗和远方`, `蓝人女王传`, `ùzhi青年`, `MM`, `Gift Exchange` — or a new one?
+
+3. **Fetch the page** — use WebFetch on the URL.
+
+4. **Extract metadata** from the page HTML:
+   - **title**: `og:title` meta tag, or the `<title>` tag (strip site name suffix like " | Medium")
+   - **date**: `article:published_time` meta tag, or `datePublished` in JSON-LD, or the visible publish date — format as `YYYY-MM-DD`
+
+5. **Slugify the title** — lowercase, replace spaces and special chars with hyphens, collapse multiple hyphens, strip leading/trailing hyphens. Example: `"My Article: A Story!"` → `my-article-a-story`
+
+6. **Write the file** to `content/blog/<slug>.md`:
+
+```yaml
+---
+title: "<title>"
+date: <YYYY-MM-DD>
+category: "<category name>"
+external_url: "<url>"
+---
+```
+
+7. **Confirm** — print the file path and the frontmatter that was written.

--- a/.claude/skills/add-writing-link/SKILL.md
+++ b/.claude/skills/add-writing-link/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: add-writing-link
+description: >
+  Add a writing article link to the hamxiaoz.github.com site.
+  Use when the user provides a Medium or LinkedIn article URL and wants
+  to create a new entry in content/writing/<subfolder>/.
+  Trigger: "add writing", "add article", "add this link", "/add-writing-link",
+  plus any time user pastes a Medium/LinkedIn URL with intent to save it to the writing section.
+allowed-tools:
+  - WebFetch
+  - Write
+  - AskUserQuestion
+---
+
+# add-writing-link
+
+Add a Medium or LinkedIn article to the writing section of hamxiaoz.github.com.
+
+## Steps
+
+1. **Parse input** — extract the URL from the user's message. Also note if they specified a subfolder (`AI`, `engineering`, `fp`, `leadership`).
+
+2. **Ask for subfolder if missing** — if no subfolder was given, ask:
+   > Which subfolder? `AI`, `engineering`, `fp`, `leadership` — or a new one?
+
+3. **Fetch the page** — use WebFetch on the URL.
+
+4. **Extract metadata** from the page HTML:
+   - **title**: `og:title` meta tag, or the `<title>` tag (strip site name suffix like " | Medium")
+   - **date**: `article:published_time` meta tag, or `datePublished` in JSON-LD, or the visible publish date — format as `YYYY-MM-DD`
+   - **cover**: `og:image` meta tag URL — omit the field entirely if not found
+
+5. **Slugify the title** — lowercase, replace spaces and special chars with hyphens, collapse multiple hyphens, strip leading/trailing hyphens. Example: `"My Article: A Story!"` → `my-article-a-story`
+
+6. **Write the file** to `content/writing/<subfolder>/<slug>.md`:
+
+```yaml
+---
+title: "<title>"
+date: <YYYY-MM-DD>
+external_url: "<url>"
+cover: "<og:image url>"
+---
+```
+
+Omit the `cover` line if no image was found.
+
+7. **Confirm** — print the file path and the frontmatter that was written.

--- a/.claude/skills/copy-obsidian-to-hugo/SKILL.md
+++ b/.claude/skills/copy-obsidian-to-hugo/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: copy-obsidian-to-hugo
+description: >
+  Copy an Obsidian markdown article and its images to the Hugo site as a page bundle
+  in content/writing/<section>/. Converts ![[wikilinks]] to standard markdown images,
+  adds Hugo frontmatter, strips platform comment blocks. Content prose is otherwise untouched.
+  Trigger: "copy to hugo", "publish to site", "add to hugo", "/copy-obsidian-to-hugo"
+allowed-tools:
+  - Read
+  - Glob
+  - Bash
+  - Write
+  - AskUserQuestion
+---
+
+# copy-obsidian-to-hugo
+
+Copy an Obsidian article and its images into the Hugo site as a page bundle under `content/writing/`.
+
+## Paths
+
+- **Obsidian Writing folder**: `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/HQ/Writing/` (iCloud-synced; same path on any of the user's Macs)
+- **Hugo site**: the repository this skill lives in — run all commands from the repo root, use repo-relative paths (`content/writing/...`)
+
+## Steps
+
+1. **Parse input** — extract the Obsidian filename or path from the user's message. If only a filename is given, look for it under the Obsidian Writing folder using Glob.
+
+2. **Ask for section if not provided:**
+   > Which writing section? `AI` / `engineering` / `fp` / `leadership` / `spaces-in-between`
+
+3. **Read the file** — full content.
+
+4. **Extract metadata:**
+   - **Title**: the first `# Heading` found in the document; fall back to the filename (spaces → title case) if none
+   - **Date**: today's date as `YYYY-MM-DD`
+   - **Images**: all `![[filename.ext]]` patterns
+
+5. **Determine slug** — from the Obsidian filename: lowercase, replace spaces and hyphens with single hyphens, strip special characters. Example: `AI Field Notes - Family Assistant.md` → `ai-field-notes-family-assistant`
+
+6. **Create the Hugo page bundle directory:**
+   ```
+   content/writing/<section>/<slug>/
+   ```
+
+7. **Copy all referenced images** from the Obsidian Writing folder to the bundle directory using `cp`.
+
+8. **Write `index.md`** to the bundle with these minimal transformations — everything else is verbatim:
+   - Prepend Hugo frontmatter if not already present:
+     ```yaml
+     ---
+     title: "<extracted title>"
+     date: <YYYY-MM-DD>
+     ---
+     ```
+   - Strip any `<!-- ... -->` HTML comment blocks (platform notes)
+   - Remove the `# Title` H1 line if it was used as the frontmatter title (avoid duplicate)
+   - Convert `![[image.png]]` → `![](image.png)`
+
+9. **Confirm** — print the bundle path, list copied images, and show the frontmatter that was written.

--- a/.claude/skills/new-blog/SKILL.md
+++ b/.claude/skills/new-blog/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: new-blog
+description: >
+  Create a new blog post in the 博客 section of hamxiaoz.github.com (content/blog/).
+  Use when the user wants to write/start/scaffold an original blog post (not an external
+  link — for Medium/LinkedIn links use add-blog-link instead).
+  Trigger: "new blog", "create a blog", "write a blog post", "start a post", "/new-blog".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# new-blog
+
+Scaffold an original blog post for hamxiaoz.github.com under `content/blog/`. The post
+renders via `layouts/blog/single.html`, gets URL `/blog/<slug>.html` (date prefix is
+stripped automatically), and appears on `/blog` under 最近, 全部, and its category.
+
+For external Medium/LinkedIn links, use `add-blog-link` instead — this skill is for
+original content authored on the site.
+
+## Steps
+
+1. **Get the title.** Take it from the user's message, or ask for it.
+
+2. **Ask: pictures or not?** Use AskUserQuestion:
+   - **With photos** → create a *page bundle*: a folder `content/blog/<date>-<slug>/index.md`,
+     with placeholder embeds and image files dropped alongside `index.md`.
+   - **No photos** → create a *flat file*: `content/blog/<date>-<slug>.md`.
+
+3. **Ask: which category?** Read the live list from `data/blogcategory.json` and offer those
+   names via AskUserQuestion, plus an "Uncategorized" option and an "Other (new category)" option.
+   - Current categories are typically: `蓝人女王传`, `ùzhi青年`, `诗和远方`, `MM`, `Gift Exchange`.
+   - Uncategorized → omit the `category` field (post still shows in 最近 and 全部).
+   - New category → write the `category` value as given; mention that to surface it as its own
+     section on `/blog`, an entry must be added to `data/blogcategory.json` (offer to do it).
+
+4. **Build the slug.** Lowercase ASCII, hyphen-separated. For Chinese titles, romanize to pinyin
+   (match existing posts, e.g. `美味厨师之` → `mei-wei-chu-shi-zhi`, `泳者之心` → `yong-zhe-zhi-xin`).
+   Collapse repeated hyphens; strip leading/trailing hyphens.
+
+5. **Date.** Default to today (`date +%Y-%m-%d`) unless the user gave one. The date prefixes the
+   filename/folder and is also written in frontmatter.
+
+6. **Write the file** with this frontmatter (drop `category` if Uncategorized):
+
+   ```yaml
+   ---
+   title: "<title>"
+   date: <YYYY-MM-DD>
+   category: "<category>"
+   ---
+   ```
+
+   - **With photos:** add a short intro line and a few placeholder embeds, then tell the user to
+     drop the image files into the folder:
+     ```markdown
+     ![](photo-1.jpg)
+     ![](photo-2.jpg)
+     ```
+     Embed images with plain markdown `![](file.jpg)` (no shortcode/gallery exists — this matches
+     the existing photo articles).
+   - **No photos:** add a short starter line or the user's provided body.
+
+7. **Chinese punctuation pass (REQUIRED for Chinese posts).** If the title or body is primarily
+   Chinese, read the FULL written content and convert ASCII punctuation in the prose to full-width
+   Chinese punctuation. See the conversion rules below. Apply with judgment — do NOT blindly regex.
+
+8. **Confirm.** Print the file/folder path and the frontmatter. If a page bundle, remind the user
+   to drop `photo-1.jpg`, `photo-2.jpg`, … into the folder (or rename embeds to match their files).
+
+## Chinese punctuation conversion
+
+When a post is Chinese, sentence punctuation should be full-width. Read the whole content and convert:
+
+| ASCII | Chinese | Notes |
+|-------|---------|-------|
+| `,` | `，` | comma between Chinese clauses |
+| `.` | `。` | sentence end (NOT decimals, version numbers, or `.md`/URLs) |
+| `?` | `？` | |
+| `!` | `！` | |
+| `:` | `：` | |
+| `;` | `；` | |
+| `(` `)` | `（` `）` | when wrapping Chinese text |
+| `"..."` | `“...”` | curly double quotes around Chinese |
+| `'...'` | `‘...’` | curly single quotes |
+| `...` | `……` | ellipsis |
+| `--` | `——` | em dash |
+
+**Do NOT convert** punctuation inside:
+- YAML frontmatter (the `---` block, `date:`, URLs, filenames)
+- code spans/blocks (between backticks or fenced ``` ```)
+- image/link markdown targets — `![](photo-1.jpg)`, `[text](https://…)`
+- English words, numbers, decimals (`3.14`), version strings, file extensions (`.jpg`)
+- HTML comments `<!-- ... -->`
+
+Leave the markdown image/link syntax and any HTML untouched. Only convert punctuation that sits
+within Chinese prose.
+
+## Quick reference
+
+| Choice | Result |
+|--------|--------|
+| With photos | `content/blog/<date>-<slug>/index.md` + image files in same folder |
+| No photos | `content/blog/<date>-<slug>.md` |
+| Uncategorized | omit `category:` from frontmatter |
+| Permalink | `/blog/<slug>.html` (date stripped) |
+
+## Common mistakes
+
+- **Using a shortcode/gallery for images** — there is none. Use plain `![](file.jpg)`.
+- **Writing the file before asking about photos/category** — ask first; structure depends on it.
+- **Converting punctuation inside frontmatter, code, or image paths** — those stay ASCII.
+- **English/numeric punctuation** — `3.14`, `v1.2`, `index.md` keep their ASCII dots.
+- **Slug from raw Chinese characters** — romanize to pinyin to match existing URLs.

--- a/.claude/skills/polish-article/SKILL.md
+++ b/.claude/skills/polish-article/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: polish-article
+description: >
+  Polish an article draft to make it ready to post on personal site, LinkedIn, or Medium.
+  Reads the draft, improves hook/flow/prose, handles Obsidian image syntax (![[...]]),
+  writes a polished version to a new file.
+  Trigger: "polish article", "polish this", "get this ready to publish", "/polish-article",
+  or when user points at a draft and says it needs to be publish-ready.
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - AskUserQuestion
+version: "1.0"
+---
+
+# polish-article
+
+Polish a draft article. 带着一个观点出发，在写的过程中把它想透
+
+## 约束
+
+### ASCII Art
+
+图表可以用纯 ASCII 字符。允许：`+ - | / \ > < v ^ * = ~ . : # [ ] ( ) _ , ; ! ' "` 和空格。禁止 Unicode 绘图符号。
+
+### 姿态
+
+一个人在想事情，碰巧被你看见。不教课，不演讲，不聊天。心里放一个具体的人，写给他，不是写给「读者们」。
+
+禁止借势：不用群体代言（"程序员都知道"）。不编造经历。不用元评论（"接下来我们讨论"）。
+
+不确定就说不确定。"大概 70%" 比 "可能" 诚实。
+
+### 最高法则：口语检验
+
+你会这样跟一个聪明的朋友说话吗？不会→改到会。
+
+这条覆盖一切。任何操作的结果过不了这关，回退。连词不是敌人——"但是"、"所以"、"就像"是思维自然转弯的声音，只砍机械连词（"此外"、"另外"、"值得注意的是"），别砍活的。
+
+### 密度
+
+- 砍：这句能删吗？能和上一句并吗？
+- 短：能用两个字说的不用四个字。「进行讨论」→「聊」。「实现功能」→「做到」。大词不让你显得聪明，只让人读得累
+- 造：一句话装两层——表面说 A，结构暗示 B
+- 选词：每个动词是一次判断。"放在"和"搁在"和"摆在"不是一回事
+- 节奏：说到要害，句子变短。展开时允许伸长。独立成段的短句整篇最多两处
+- 反模板：同一种句式结构最多出现一次
+
+### 素材
+
+默认喻体：计算机体系思想。操作系统、编译器、网络协议、存储层级、指令流水线、虚拟内存、进程调度——不是比喻来源，是思维本身。出现时像母语，不像引用。
+
+跨域类比：结构对得上，不是表面像。一个打透胜过三个排列。
+
+### 抽象层级
+
+每件事都有多个抽象层，解释的艺术在于选对层。
+
+- 太高（"计算机就是处理信息的"）→ 正确但无用
+- 太低（"晶体管的阈值电压决定了……"）→ 淹死在细节里
+- 刚好：往上能看见全貌，往下能感觉到机制在运转
+
+一篇文章里可以跨层——但每次跨层像函数调用：跳下去，拿到东西，跳回来。
+
+### 自检
+
+- 任意助手都能写的句子 → 改或删
+- 正在"解释"的感觉 → 换成一个看得见的场景
+- 同一个论点出现两次 → 第一次没说透。改第一次，删重复
+
+## 声音
+
+生成器：*用不对称的容器装正经的内容*。技术语言说人间事，大白话切哲学问题。
+
+参考频率：Paul Graham 的对话感和反直觉切入，王小波的手术刀幽默，钱钟书的一句三层。不模仿任何一个。
+
+引擎：计算机体系是母语。缓存失效、中断处理、虚拟地址映射在文章里出现时，应该像呼吸一样自然。
+
+思维的毛边可以露出来。"等等，这不对"、"有意思"——不是表演犹豫，是真的在想。
+
+## Steps
+
+1. **Find the file** — extract the file path or filename from the user's message. If none was given, ask:
+   > Which file should I polish? (paste the path or filename)
+
+2. **Ask for target platform** — if the user hasn't said, ask:
+   > Which platform(s)? `site` / `LinkedIn` / `Medium` / `all`
+
+3. **Read the draft** — use the Read tool to load the full file content.
+
+
+4. do the following steps to polish
+
+### 一、找核
+
+表面说的和真正在说的，往往不是一回事。往下挖一层。
+
+三把铲子：
+- *反转*：把判断反过来。反面是废话 → 原判断太平庸，继续挖
+- *追问前提*：这个判断站在什么假设上？假设往往比判断更值得写
+- *追问情绪*：为什么这件事让人不舒服/兴奋/困惑？情绪指向未被说出的认知冲突
+
+验收：能用一句话说清核心。说不清 → 有多个核 → 只留一个。挖不动 → 观点本身就是底，没有文章可写，告诉用户。
+
+### 二、攻核
+
+找到核之后，攻击它。对着核问一个让前提自爆的问题——"如果这是真的，那为什么……？"
+
+三种结果：
+- 核扛住了 → 带着更强的置信度往下走
+- 核变形了 → 回到步骤一，用变形后的核重走
+- 核碎了 → 观点不成立。告诉用户：这里有个更值得写的东西
+
+跳过这步 = 扩写一个没想透的观点。
+
+### 三、找类比
+
+为核找一个结构对得上的日常类比。常用类比: 体育, 家庭, 电脑, popular brand such as netflix, google etc.
+
+抓住核的动词结构——它在干什么，什么作用于什么，什么流向什么。在日常经验里找结构一样的东西。
+
+好类比承重：去掉它整篇文章塌掉。好类比多层：往下挖一层还像，最好三层以上。好类比自明：读者不需要解释就能看懂类比本身。
+
+### 四、展开并写
+
+输出是一篇从第一行流到最后一行的连贯文章。禁止结构标签（`* 核` / `* 类比` / `* 裂缝`），禁止子标题，禁止指向思考过程的元评论。
+
+**开头：** 第一句话给读者一个理由继续读。一个反直觉的判断、一个画面、一个问题。不铺垫、不背景、不「自古以来」。类比直接落地，读者还没反应过来已经在里面了。
+
+**展开：** 让类比自己走。概念的每个子部分对应类比的一个部分。每段一个认知增量——两个就拆，零个就删。每句一件事——句子短，读者快。拔掉任一段链条应该断，不断就删。同一个论点只用一个例子，一个不够说明例子选错了。类比覆盖不到的地方补一个小类比，用完就走。
+
+**裂缝：** 类比在哪里撑不住了？那个点就是文章最值钱的段落。不宣布"类比在这里失效"，让读者自己感到对不上了。用叙事推过去。
+
+**反问入链：** 遇到隐含前提，用一个问题打开。"但等一下——如果真是这样，为什么……？" 然后回答它。
+
+**结尾不总结。** 结尾是最后一个发现，或者一扇门——指向你没写但读者会自己去想的方向。
+
+**语气是探索性的：** "X 看起来是一回事，但如果你……等等，这意味着 Y。" 读者跟着你一起走到结论，不是被告知结论。
+
+### 五、磨
+
+初稿出来后：
+
+1. **口语检验**：逐段读。你会这样跟朋友说吗？不会→改。最高优先级。
+2. **按约束逐段扫**：密度、节奏、选词、反模板。压缩后再过一遍口语——嘴说不出来了就回退。
+3. **过滤 AI 痕迹**：
+   - 删填充——拐杖词、夸大象征（「标志着」「见证了」）、宣传腔（「充满活力」「开创性的」）
+   - 破公式——否定式排比全文不超过两处，三段式改两项或四项
+   - 变节奏——长短句交替，同一段破折号不超过一个
+   - 信任读者——跳过软化和过度解释
+   - 杀金句——听起来像可引用的，重写
+
+扫完列修改清单（哪句触发什么，改前→改后），确认后写入文件。
+
+**意外检验：** 写这篇文章的过程中，你发现了什么自己之前没想到的？有→确认它在文中够显眼。没有→回到攻核，攻得不够狠。
+
+5. also remember write with these goals:
+   - Sharpen the opening hook — it must earn the reader's attention in the first two sentences
+   - Cut filler words and redundant phrases; tighten every sentence
+   - Ensure smooth transitions between sections
+   - Preserve the author's voice and key examples — don't sanitize the personality out
+   - Keep the structure (headers, blockquotes, bullet lists) unless it hurts readability
+   - Handle Obsidian image embeds (`![[filename.png]]`) per platform rules below
+
+   **Platform rules:**
+
+   | Platform | Formatting | Images |
+   |---|---|---|
+   | `site` | Keep all markdown | keep using Obsidian wikilink `![[image.png]]` |
+   | `LinkedIn` | Strip all markdown (no `**bold**`, no `#` headers, no `>` quotes) — use plain paragraphs and blank lines; add a strong 1–2 line hook at the very top | Remove `![[...]]` lines entirely; add `[image]` placeholder where relevant |
+   | `Medium` | Keep markdown | Replace `![[img.png]]` with `> 📷 Insert image: img.png` |
+   | `all` | Use clean markdown that works across platforms | Handle images as for `site`; add a note at the top listing any per-platform adjustments needed |
+
+5. **Determine output filename** — append `_polished` before the extension. Examples:
+   - `Article Draft.md` → `Article Draft_polished.md`
+   - `AI Field Note - Family Assistant v2.md` → `AI Field Note - Family Assistant v2_polished.md`
+   Write the polished file to the same directory as the original using the Write tool.

--- a/.claude/skills/publish-hugo-article/SKILL.md
+++ b/.claude/skills/publish-hugo-article/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: publish-hugo-article
+description: >
+  Publish a Hugo markdown article to Medium, LinkedIn, and/or X (Twitter).
+  Interactively guides step-by-step: generates a LinkedIn hook, hashtags for all
+  platforms, and a tweet draft — asks for confirmation at each step before writing
+  to frontmatter or calling any publishing API.
+  Trigger: "/publish-hugo-article", "publish article", "publish this to medium",
+  "publish to linkedin", "post this article", "share article".
+  Uses scripts/publish.py as the publishing engine (handles API calls).
+allowed-tools:
+  - Read
+  - Glob
+  - Edit
+  - Bash
+  - AskUserQuestion
+---
+
+You are running the `publish-hugo-article` skill. Follow these steps in order.
+Do NOT skip steps. Do NOT publish anything without explicit user confirmation.
+
+---
+
+## STEP 1 — Identify the article
+
+If the user provided a file path, use it. Otherwise:
+1. Run (from the repo root): `find content/writing -name "*.md" ! -name "_index.md" -newer content/writing -maxdepth 3 | head -10` to find recent articles
+2. Use Glob to list files in `content/writing/**/*.md` (excluding `_index.md`)
+3. Ask the user which article to publish using AskUserQuestion
+
+Read the article file fully before proceeding.
+
+---
+
+## STEP 2 — Check publish state
+
+Look at the frontmatter for existing `medium_url`, `linkedin_posted`, `x_posted` fields.
+If any platform is already published, tell the user and ask if they want to re-publish (use `--force` flag).
+
+---
+
+## STEP 3 — Generate suggestions
+
+Read the article title and body carefully. Then generate ALL of the following yourself (no API call needed — you generate these inline):
+
+### LinkedIn hook
+Write 1–2 sentences that:
+- Open with a provocative insight, counterintuitive claim, or relatable pain point
+- Do NOT start with "I" or the article title
+- Target the professional audience implied by the article topic
+- End with a subtle forward pull (make them want to read on)
+
+### LinkedIn hashtags
+5–7 hashtags. Mix: 1–2 broad (#Engineering, #Leadership), 2–3 topic-specific, 1–2 niche. Format: `#Tag1 #Tag2 #Tag3`
+
+### Medium tags
+3–5 tags as plain lowercase words (no `#`). These are Medium's tag taxonomy — use common ones like `engineering`, `leadership`, `ai`, `programming`, `productivity`.
+
+### X post
+A complete tweet:
+- Start with the hook (condensed to 1 punchy sentence)
+- Include `{url}` as placeholder (replaced at publish time)
+- End with 3–4 hashtags
+- Total length ≤ 240 characters (leaves room for the URL)
+
+### X hashtags
+3–4 hashtags for X. Shorter and punchier than LinkedIn.
+
+---
+
+## STEP 4 — Confirm the LinkedIn hook
+
+Present the hook clearly and ask:
+
+```
+Here's the LinkedIn hook I generated:
+
+"{hook}"
+
+What would you like to do?
+```
+
+Use AskUserQuestion with options:
+- "Use this hook"
+- "Suggest 2 alternatives"
+- "I'll write my own" (then ask them to type it)
+
+If they choose "Suggest 2 alternatives", generate 2 more and ask again.
+If they choose "I'll write my own", use AskUserQuestion to collect their text.
+
+---
+
+## STEP 5 — Confirm hashtags and tags
+
+Show all platform metadata together and ask for approval:
+
+```
+Here are the suggested tags/hashtags:
+
+LinkedIn hashtags: {linkedin_hashtags}
+Medium tags: {medium_tags}
+X hashtags: {x_hashtags}
+X post preview: {x_post}
+```
+
+Use AskUserQuestion:
+- "Approve all"
+- "Edit LinkedIn hashtags"
+- "Edit Medium tags"  
+- "Edit X post/hashtags"
+
+If they want to edit, use AskUserQuestion to collect the replacement text.
+
+---
+
+## STEP 6 — Write to frontmatter
+
+After hook + hashtags are confirmed, use the Edit tool to add/update these fields in the article's frontmatter (between the `---` delimiters). Add them after existing fields:
+
+```yaml
+linkedin_hook: "{confirmed hook}"
+linkedin_hashtags: "{confirmed hashtags}"
+medium_tags: ["{tag1}", "{tag2}", "{tag3}"]
+x_post: "{confirmed x post with {url} placeholder}"
+x_hashtags: "{confirmed x hashtags}"
+```
+
+Use targeted replacement: find the closing `---` of the frontmatter and insert before it. Do NOT rewrite existing frontmatter fields.
+
+Tell the user: "I've written the suggestions to the article frontmatter. You can always edit them directly in the file before publishing."
+
+---
+
+## STEP 7 — Choose platforms
+
+Ask the user which platforms to publish to using AskUserQuestion with multiSelect: true:
+
+Options:
+- "Medium (draft)" — publishes as hidden draft for review before going public
+- "Medium (public)" — goes live immediately  
+- "LinkedIn (full article)"
+- "X (post)"
+
+---
+
+## STEP 8 — Publish
+
+For each selected platform, show a preview and confirm before calling the script.
+
+### Before each publish, confirm:
+
+**Medium draft:**
+> "Ready to publish to Medium as a DRAFT. You'll need to log into Medium to make it public.
+> Title: {title}
+> Tags: {medium_tags}"
+> Confirm?
+
+**Medium public:**
+> "Ready to publish to Medium as PUBLIC (goes live immediately).
+> Title: {title}
+> Tags: {medium_tags}"
+> Confirm?
+
+**LinkedIn:**
+> "Ready to publish full article to LinkedIn.
+> Hook: {linkedin_hook}
+> Hashtags: {linkedin_hashtags}"
+> Confirm?
+
+**X:**
+> "Ready to post to X:
+> {x_post with url substituted if medium_url available, otherwise '{url}' shown literally}
+> ({char_count}/280 chars)"
+> Confirm?
+
+### Run the script (only after confirmation):
+
+Check that `scripts/publish.py` exists first. If it doesn't, tell the user to run the setup.
+
+Run all commands from the repo root with `python3`:
+
+```bash
+# Medium draft
+python3 scripts/publish.py {article_path} --medium
+
+# Medium public  
+python3 scripts/publish.py {article_path} --medium --publish
+
+# LinkedIn
+python3 scripts/publish.py {article_path} --linkedin
+
+# X
+python3 scripts/publish.py {article_path} --x
+```
+
+Show the output of each command. If a command fails, show the error and suggest fixes (missing `.env` credentials, expired token, etc.).
+
+---
+
+## STEP 9 — Summary
+
+After all publishing is done, show a summary:
+
+```
+Published successfully:
+- Medium draft: {url or "pending"}
+- LinkedIn: posted ✓
+- X: posted ✓
+
+The article frontmatter has been updated with publish status.
+Next: run `hugo server` to verify the site card links to the correct external URL.
+```
+
+If any platform failed, note it clearly and suggest re-running just that platform.
+
+---
+
+## Error handling
+
+**Missing `.env` or credentials:**
+Tell the user exactly which variable is missing and where to get it:
+- `MEDIUM_TOKEN`: medium.com → Settings → Integration tokens
+- `MEDIUM_AUTHOR_ID`: run `python3 scripts/publish.py --whoami-medium`
+- `LINKEDIN_ACCESS_TOKEN`: run `python scripts/linkedin_auth.py`
+- `LINKEDIN_PERSON_URN`: printed by `linkedin_auth.py`
+- `X_*` credentials: run `python scripts/x_auth.py`
+
+**Already published:**
+Show existing URL and ask if they want to republish with `--force`.
+
+**LinkedIn API restricted:**
+If the script reports the Articles API is restricted, explain that LinkedIn requires Partner Program access for native article publishing. Offer to fall back to a long-form post instead.


### PR DESCRIPTION
Move the six site-specific Claude Code skills from the global `~/.claude/skills/` folder into the repo at `.claude/skills/` so they travel with the clone and stay alongside their `scripts/` dependency.

**Skills added:**
- `publish-hugo-article` (pairs with `scripts/publish.py`)
- `add-blog-link`, `add-writing-link`
- `copy-obsidian-to-hugo`
- `new-blog`, `polish-article`

**Changes:**
- Replace hardcoded `/Users/andrew/...` paths with repo-relative paths so skills work on any machine
- Credentials still load from a gitignored `.env` file (see `.env.example`)